### PR TITLE
All urls are now absolute urls in the editor.

### DIFF
--- a/src/fulcro_atlaskit/editor.cljs
+++ b/src/fulcro_atlaskit/editor.cljs
@@ -435,7 +435,7 @@
           children)
       "link"
         (if read-only?
-          (dom/a {:href url} children)
+          (dom/a {:href (cond->> url (not (str/starts-with? url "http")) (str "//"))} children)
           (comp/with-parent-context
             this
             (ui-url-editor


### PR DESCRIPTION
Urls such as www.google.com would become /jira/atlascrm/companies/www.google.com. Prefixing this urls with // makes it an absolute url

Resolves: ACSD-624